### PR TITLE
feat: adding registry.k8s.io

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,15 @@ services:
     environment:
       REGISTRY_PROXY_REMOTEURL: https://registry.gitlab.com
     restart: always
+  registry-k8s:
+    image: registry:2@sha256:ac0192b549007e22998eb74e8d8488dcfe70f1489520c3b144a6047ac5efbe90
+    volumes:
+      - ./data:/var/lib/registry
+    ports:
+      - "5007:5000"
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://registry.k8s.io
+    restart: always
 
 
 #https://distribution.github.io/distribution/recipes/mirror/


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new service `registry-k8s` to `docker-compose.yml`.

- Configured `registry-k8s` to use `registry.k8s.io` as the proxy remote URL.

- Assigned a unique port (5007) for the `registry-k8s` service.

- Ensured `registry-k8s` uses the same volume and restart policy as other services.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Introduced `registry-k8s` service in Docker Compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Added a new service <code>registry-k8s</code> to the configuration.<br> <li> Configured <code>registry-k8s</code> with a specific image and proxy URL.<br> <li> Assigned port 5007 to the <code>registry-k8s</code> service.<br> <li> Ensured consistent volume and restart policy for <code>registry-k8s</code>.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/docker-compose-container-registry-pull-through-caches/pull/18/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information