### PR TITLE
chore: update registry-k8s docker registry image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       REGISTRY_PROXY_REMOTEURL: https://registry.gitlab.com
     restart: always
   registry-k8s:
-    image: registry:2@sha256:ac0192b549007e22998eb74e8d8488dcfe70f1489520c3b144a6047ac5efbe90
+    image: registry:2@sha256:26f7266535a3a1dae81e137ba4935c59d96e7bb4b700f64e4af8959ca5ab0419
     volumes:
       - ./data:/var/lib/registry
     ports:


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the Docker image for `registry-k8s` service.

- Ensured compatibility with the new image hash.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Update Docker image hash for `registry-k8s`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Updated the Docker image hash for <code>registry-k8s</code>.<br> <li> Maintained existing service configuration and ports.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/docker-compose-container-registry-pull-through-caches/pull/19/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information