### PR TITLE
feat: Add public mirror for GPKG IO registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,15 @@ services:
     environment:
       REGISTRY_PROXY_REMOTEURL: https://registry.k8s.io
     restart: always
+  public-mirror-gpkg-io:
+    image: registry:3@sha256:3725021071ec9383eb3d87ddbdff9ed602439b3f7c958c9c2fb941049ea6531d
+    volumes:
+      - ./data:/var/lib/registry
+    ports:
+      - "5008:5000"
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://public-mirror.gpkg.io
+    restart: always
 
 
 #https://distribution.github.io/distribution/recipes/mirror/


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add new Docker registry service for GPKG IO mirror

- Configure proxy to public-mirror.gpkg.io on port 5008


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Compose"] --> B["public-mirror-gpkg-io service"]
  B --> C["Registry:3 image"]
  B --> D["Port 5008:5000"]
  B --> E["Proxy to public-mirror.gpkg.io"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Add GPKG IO registry mirror service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Add new <code>public-mirror-gpkg-io</code> service configuration<br> <li> Configure registry proxy to <code>https://public-mirror.gpkg.io</code><br> <li> Map service to port 5008 with volume mount<br> <li> Set restart policy to always</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/docker-compose-container-registry-pull-through-caches/pull/25/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

